### PR TITLE
Change scheduled-tasks cron to 05:00 Europe/Oslo and add workflow_dispatch to deploy

### DIFF
--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   maven-build-and-releas:

--- a/.github/workflows/scheduled-tasks.yml
+++ b/.github/workflows/scheduled-tasks.yml
@@ -2,7 +2,7 @@ name: Scheduled Workflow Tasks
 on:
   workflow_dispatch:
   schedule:
-    - cron: '30 08 * * 1-5'
+    - cron: '0 04 * * 1-5'
 
 jobs:
   # Dependabot auto-merges via `gh pr merge --auto` are performed by

--- a/.github/workflows/scheduled-tasks.yml
+++ b/.github/workflows/scheduled-tasks.yml
@@ -2,7 +2,8 @@ name: Scheduled Workflow Tasks
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 04 * * 1-5'
+    - cron: '0 05 * * 1-5'
+      timezone: "Europe/Oslo"
 
 jobs:
   # Dependabot auto-merges via `gh pr merge --auto` are performed by


### PR DESCRIPTION
1. Changes `scheduled-tasks.yml` to run at 05:00 Norwegian time (Europe/Oslo) instead of 08:30 UTC. Using an IANA timezone string means the schedule is always correct regardless of DST transitions.

2. Adds `workflow_dispatch:` trigger to the deploy workflow. Without this, `trigger-missed-dependabot-deploy` cannot dispatch the workflow when it detects a missed dependabot deploy (GitHub returns HTTP 422).